### PR TITLE
Remove healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,4 @@ ADD start.sh /start.sh
 
 CMD chmod +x /start.sh && \
     /start.sh
-    
-HEALTHCHECK CMD https_proxy=http://localhost:3128 \
-                http_proxy=http://localhost:3128 \
-                curl --fail https://www.google.com/ || exit 1
+


### PR DESCRIPTION
Should the docker container fail or restart when an external service (the upstream proxy) does not work? If not, please accept this change :)