### PR TITLE
Change `chmod +x` to be a RUN in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,6 @@ ENV NOPROXY    UNSET
 EXPOSE 3128
 
 ADD start.sh /start.sh
+RUN chmod +x /start.sh
 
-CMD chmod +x /start.sh && \
-    /start.sh
+CMD /start.sh


### PR DESCRIPTION
When attempting the start the proxy with `docker run` the message `/bin/sh: /start.sh: Text file busy` is shown.

I've changed the Dockerfile so the image is built with the script having executable permission instead of setting it at the entry point. This appears to fix the issue.